### PR TITLE
Handle exceptions from adapters and the test code better.

### DIFF
--- a/trafficlight/http/adapter.py
+++ b/trafficlight/http/adapter.py
@@ -107,7 +107,11 @@ async def error(uuid: str):  # type: ignore
         logger.info("Got error from ${uuid}, unable to route internally\n${response}")
         raise Exception("Unknown adapter raising error")
 
+    if error_json is None:
+        raise Exception("Error request did not include a JSON body")
+
     update = cast(Dict[str, Any], error_json)
+
     # Using the same API format as sentry to capture the error in a reasonable way:
     error_body = update["error"]
 

--- a/trafficlight/http/adapter.py
+++ b/trafficlight/http/adapter.py
@@ -21,7 +21,7 @@ from werkzeug.utils import secure_filename
 from trafficlight.homerunner import HomerunnerClient
 from trafficlight.internals.adapter import Adapter
 from trafficlight.store import add_adapter, get_adapter, get_adapters, get_tests
-
+from trafficlight.internals.exceptions import AdapterException, ActionException
 # Set transitions' log level to INFO; DEBUG messages will be omitted
 
 
@@ -113,9 +113,26 @@ async def error(uuid: str):  # type: ignore
     update = cast(Dict[str, Any], error_json)
 
     # Using the same API format as sentry to capture the error in a reasonable way:
+    #{
+    #    "error": {
+    #        "type": "unknown" | "action"
+    #        "path": "path/to/error"
+    #        "details": "human/details_go_here"
+    #    }
+    #}
     error_body = update["error"]
+    exception: Exception
+    cause: str
+    if adapter.client:
+        cause = f"Error from adapter for client {adapter.client.name}"
+    else:
+        cause = f"Error from adapter {adapter.guid}"
+    if error_body["type"] == "action":
+        exception = ActionException(cause + '\n' + error_body['details'], error_body['path'])
+    else:
+        exception = AdapterException(cause + '\n' + error_body['details'], error_body['path'])
 
-    adapter.error(error_body)
+    adapter.error(exception)
 
     return {}
 

--- a/trafficlight/internals/adapter.py
+++ b/trafficlight/internals/adapter.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 from trafficlight.internals.client import Client
-
+from trafficlight.internals.exceptions import AdapterException, ActionException
+from typing import Union
 logger = logging.getLogger(__name__)
 
 
@@ -53,7 +54,7 @@ class Adapter(object):
         if update_last_responded:
             self.last_responded = datetime.now()
 
-    def error(self, error: Dict[str, str], update_last_responded: bool = True) -> None:
+    def error(self, error: Union[AdapterException, ActionException], update_last_responded: bool = True) -> None:
         # If we error, always mark us as completed
         self.completed = True
         self.last_error = error
@@ -66,11 +67,11 @@ class Adapter(object):
                 self.guid,
             )
             return
-        exception = Exception(f"{error} from adapter")
-        self.client._give_poll_exception(exception)
-
         if update_last_responded:
             self.last_responded = datetime.now()
+
+        self.client._give_poll_exception(error)
+
 
     def upload(self, name: str, path: str, update_last_responded: bool = True) -> None:
         if self.client is None:

--- a/trafficlight/internals/adapter.py
+++ b/trafficlight/internals/adapter.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 
 from trafficlight.internals.client import Client
-from trafficlight.internals.exceptions import AdapterException, ActionException
-from typing import Union
+
 logger = logging.getLogger(__name__)
 
 
@@ -16,7 +15,7 @@ class Adapter(object):
         self.last_responded: Optional[datetime] = None
         self.registered = datetime.now()
         self.completed = False
-        self.last_error: Optional[Dict[str, str]] = None
+        self.last_error: Optional[Exception] = None
         # After allocation to a TestCase, this becomes valid and is where
         # updates should be passed to.
         self.client: Optional[Client] = None
@@ -54,7 +53,11 @@ class Adapter(object):
         if update_last_responded:
             self.last_responded = datetime.now()
 
-    def error(self, error: Union[AdapterException, ActionException], update_last_responded: bool = True) -> None:
+    def error(
+        self,
+        error: Exception,
+        update_last_responded: bool = True,
+    ) -> None:
         # If we error, always mark us as completed
         self.completed = True
         self.last_error = error
@@ -71,7 +74,6 @@ class Adapter(object):
             self.last_responded = datetime.now()
 
         self.client._give_poll_exception(error)
-
 
     def upload(self, name: str, path: str, update_last_responded: bool = True) -> None:
         if self.client is None:

--- a/trafficlight/internals/exceptions.py
+++ b/trafficlight/internals/exceptions.py
@@ -1,12 +1,16 @@
 class RemoteException(Exception):
     def __init__(self, details: str, path: str):
-        self.formatted_message = f"{self.__class__.__name__} from adapter\n{details}\nIn file {path}\n"
+        self.formatted_message = (
+            f"{self.__class__.__name__} from adapter\n{details}\nIn file {path}\n"
+        )
+
 
 class ActionException(RemoteException):
     """
     Raised when an action on an adapter fails
     Generated when "type": "action"
     """
+
     pass
 
 
@@ -16,4 +20,5 @@ class AdapterException(RemoteException):
 
     Generated when "type": is not "action".
     """
+
     pass

--- a/trafficlight/internals/exceptions.py
+++ b/trafficlight/internals/exceptions.py
@@ -1,0 +1,19 @@
+class RemoteException(Exception):
+    def __init__(self, details: str, path: str):
+        self.formatted_message = f"{self.__class__.__name__} from adapter\n{details}\nIn file {path}\n"
+
+class ActionException(RemoteException):
+    """
+    Raised when an action on an adapter fails
+    Generated when "type": "action"
+    """
+    pass
+
+
+class AdapterException(RemoteException):
+    """
+    Raised when the adapter itself fails.
+
+    Generated when "type": is not "action".
+    """
+    pass

--- a/trafficlight/internals/exceptions/__init__.py
+++ b/trafficlight/internals/exceptions/__init__.py
@@ -1,2 +1,0 @@
-class BadActionException(BaseException):
-    pass

--- a/trafficlight/internals/test.py
+++ b/trafficlight/internals/test.py
@@ -35,7 +35,11 @@ class Test(object):
         self.server_type = server_type
         self.server_names = names
 
-    def _client_under_test(self, client_types: List[ClientType], name: str) -> None:
+    def _client_under_test(
+        self,
+        client_types: List[ClientType],
+        name: str,
+    ) -> None:
         self.clients[name] = client_types
 
     def _network_proxy(self, name: str) -> None:

--- a/trafficlight/internals/testcase.py
+++ b/trafficlight/internals/testcase.py
@@ -7,8 +7,9 @@ from trafficlight.client_types import ClientType
 from trafficlight.homerunner import HomerunnerClient, HomeServer
 from trafficlight.internals.adapter import Adapter
 from trafficlight.internals.client import MatrixClient, NetworkProxyClient
-from trafficlight.server_types import ServerType
 from trafficlight.internals.exceptions import ActionException, AdapterException
+from trafficlight.server_types import ServerType
+
 logger = logging.getLogger(__name__)
 
 
@@ -89,10 +90,10 @@ class TestCase:
             self.state = "running"
             await self.test.run(**kwargs)
             self.state = "success"
-        except AssertionError as e:
+        except AssertionError:
             # Treating a test that throws an assertionError as a failure
             self.state = "failed"
-            self.exceptions.append("".join(traceback.format_exception(e)))
+            self.exceptions.append("".join(traceback.format_exc()))
         except ActionException as e:
             # Treating an adapter that fails to perform an action as a failure
             self.state = "failed"
@@ -101,10 +102,10 @@ class TestCase:
             # Treating an adapter that causes another type of exception as an error
             self.state = "error"
             self.exceptions.append(e.formatted_message)
-        except Exception as e:
+        except Exception:
             # Treating everything else as an error as well... eg compilation failures
             self.state = "error"
-            self.exceptions.append("".join(traceback.format_exception(e)))
+            self.exceptions.append("".join(traceback.format_exc()))
         finally:
             for adapter in adapters.values():
                 adapter.finished()

--- a/trafficlight/templates/status_case.j2.html
+++ b/trafficlight/templates/status_case.j2.html
@@ -13,8 +13,8 @@ setTimeout(function(){
       <tr><td>Clients</td><td>{% for (name, type) in test.client_types.items()  %}{{ name }} ( {{ type }} ) {% endfor %}</td></tr>
       <tr><td>Server(s)</td><td>{{ test.server_type.name() }}</td></tr>
       <tr><td>Status</td><td>{{ test.state }}</td></tr>
-      {% if test.state == "error" %}
-      <tr><td>Error</td><td><blockquote>{{ test.error }}</blockquote></td></tr>
+      {% if test.state == "error" or test.state == "failed" %}
+      <tr><td>Errors</td><td>{% for exception in test.exceptions %}<pre>{{ exception }}</pre>{% endfor %}</td></tr>
       {% endif %}
       </tbody>
   </table>
@@ -27,7 +27,7 @@ setTimeout(function(){
     </thead>
     <tbody>
     {% for (client_name, adapter) in test.adapters.items() %}
-<   <tr>
+    <tr>
         <td>{{ client_name }}</td>
         <td>{{ adapter.guid }}</td>
         <td>{{ adapter.poll(update_last_polled=False)['action'] }}</td>


### PR DESCRIPTION
Keep a list of exceptions rather than just the last one (just in case), and display them all in the UI if an error occurs. 

Split exceptions by type from the adapter - adapter ones vs action ones.