### PR TITLE
Swap all uses of SynapseStable to SynapseDevelop

### DIFF
--- a/trafficlight/tests/dehydrated_device_test.py
+++ b/trafficlight/tests/dehydrated_device_test.py
@@ -2,7 +2,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class DehydratedDeviceTest(Test):
@@ -10,7 +10,7 @@ class DehydratedDeviceTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice")
         self._client_under_test([ElementWebStable()], "bob")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice: MatrixClient, bob: MatrixClient, server: HomeServer

--- a/trafficlight/tests/hydrogen_actions_demo.py
+++ b/trafficlight/tests/hydrogen_actions_demo.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import HydrogenWeb
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 # Test Script:
 # CLIENT_COUNT=0 REQUIRES_HYDROGEN=true HYDROGEN_APP_URL="http://localhost:3000" ./trafficlight/scripts-dev/run-localdev-setup.sh && tmux kill-server
@@ -14,7 +14,7 @@ class HydrogenActionsTest(Test):
     def __init__(self) -> None:
         super().__init__()
         self._client_under_test([HydrogenWeb()], "alice")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self,

--- a/trafficlight/tests/invited_user_decrypt_prejoin_messages_more_clients_testsuite.py
+++ b/trafficlight/tests/invited_user_decrypt_prejoin_messages_more_clients_testsuite.py
@@ -6,7 +6,7 @@ from trafficlight.client_types import ElementWebStable, HydrogenWeb
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class InviteUserDecryptPrejoinMessagesMoreUsersTest(Test):
@@ -23,7 +23,7 @@ class InviteUserDecryptPrejoinMessagesMoreUsersTest(Test):
         self._client_under_test([HydrogenWeb()], "lucas")
         self._client_under_test([HydrogenWeb()], "isabella")
         self._client_under_test([HydrogenWeb()], "william")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self,

--- a/trafficlight/tests/invited_user_decrypt_prejoin_messages_test.py
+++ b/trafficlight/tests/invited_user_decrypt_prejoin_messages_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class InviteUserDecryptPrejoinMessagesTestSuite(Test):
@@ -12,7 +12,7 @@ class InviteUserDecryptPrejoinMessagesTestSuite(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice")
         self._client_under_test([ElementWebStable()], "bob")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice: MatrixClient, bob: MatrixClient, server: HomeServer

--- a/trafficlight/tests/key_restore_marks_session_as_verified_test.py
+++ b/trafficlight/tests/key_restore_marks_session_as_verified_test.py
@@ -2,7 +2,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 # Test Command:
 # CLIENT_COUNT=2 CYPRESS_BASE_URL="https://develop.element.io"
@@ -14,7 +14,7 @@ class KeyRestoreMarksSessionAsVerifiedTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice_one")
         self._client_under_test([ElementWebStable()], "alice_two")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice_one: MatrixClient, alice_two: MatrixClient, server: HomeServer

--- a/trafficlight/tests/message_decryption_after_storage_cleared_test.py
+++ b/trafficlight/tests/message_decryption_after_storage_cleared_test.py
@@ -2,7 +2,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class MessageDecryptionAfterStorageClearedTest(Test):
@@ -10,7 +10,7 @@ class MessageDecryptionAfterStorageClearedTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice")
         self._client_under_test([ElementWebStable()], "bob")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice: MatrixClient, bob: MatrixClient, server: HomeServer

--- a/trafficlight/tests/message_decryption_when_own_hs_offline_test.py
+++ b/trafficlight/tests/message_decryption_when_own_hs_offline_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient, NetworkProxyClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class MessageDecryptionWhenOwnHSOfflineTest(Test):
@@ -14,7 +14,7 @@ class MessageDecryptionWhenOwnHSOfflineTest(Test):
         self._client_under_test([ElementWebStable()], "bob_one")
         self._client_under_test([ElementWebStable()], "bob_two")
         self._network_proxy("network_proxy")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self,

--- a/trafficlight/tests/message_warning_test.py
+++ b/trafficlight/tests/message_warning_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class MessageWarningTest(Test):
@@ -12,7 +12,7 @@ class MessageWarningTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice")
         self._client_under_test([ElementWebStable()], "bob")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice: MatrixClient, bob: MatrixClient, server: HomeServer

--- a/trafficlight/tests/retry_sendToDevice_test.py
+++ b/trafficlight/tests/retry_sendToDevice_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient, NetworkProxyClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class RetrySendToDeviceTest(Test):
@@ -12,7 +12,7 @@ class RetrySendToDeviceTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice")
         self._client_under_test([ElementWebStable()], "bob")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
         self._network_proxy("network_proxy")
 
     async def run(

--- a/trafficlight/tests/send_messages_and_demo_matrix_nio_test.py
+++ b/trafficlight/tests/send_messages_and_demo_matrix_nio_test.py
@@ -6,7 +6,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ class SendMessagesTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "client_one")
 
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(self, client_one: MatrixClient, server: HomeServer) -> None:
         nio_client = AsyncClient(

--- a/trafficlight/tests/test_verification_when_todevice_message_out_of_order_test.py
+++ b/trafficlight/tests/test_verification_when_todevice_message_out_of_order_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient, NetworkProxyClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 # Test Script:
 # CLIENT_COUNT=2 REQUIRES_PROXY=true CYPRESS_BASE_URL="https://develop.element.io"
@@ -16,7 +16,7 @@ class VerifyWhenToDeviceMessagesOutOfOrder(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice_one")
         self._client_under_test([ElementWebStable()], "alice_two")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
         self._network_proxy("network_proxy")
 
     async def run(

--- a/trafficlight/tests/verify_client_multiple_device_test.py
+++ b/trafficlight/tests/verify_client_multiple_device_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class VerifyClientMultipleDeviceTestSuite(Test):
@@ -12,7 +12,7 @@ class VerifyClientMultipleDeviceTestSuite(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice")
         self._client_under_test([ElementWebStable()], "bob")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice: MatrixClient, bob: MatrixClient, server: HomeServer

--- a/trafficlight/tests/verify_client_test.py
+++ b/trafficlight/tests/verify_client_test.py
@@ -4,7 +4,7 @@ from trafficlight.client_types import ElementWebStable
 from trafficlight.homerunner import HomeServer
 from trafficlight.internals.client import MatrixClient
 from trafficlight.internals.test import Test
-from trafficlight.server_types import SynapseStable
+from trafficlight.server_types import SynapseDevelop
 
 
 class VerifyClientTest(Test):
@@ -12,7 +12,7 @@ class VerifyClientTest(Test):
         super().__init__()
         self._client_under_test([ElementWebStable()], "alice_one")
         self._client_under_test([ElementWebStable()], "alice_two")
-        self._server_under_test(SynapseStable(), ["server"])
+        self._server_under_test(SynapseDevelop(), ["server"])
 
     async def run(
         self, alice_one: MatrixClient, alice_two: MatrixClient, server: HomeServer


### PR DESCRIPTION
Until we start testing both, we want to stay with the develop versions of deployments.