### PR TITLE
Use JSON config instead of ENVVAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ Passing in envvars below will forward them to the application as expected.
 
 ## Configuring
 
-Various options can be used to configure the tests:
+Various options can be used to configure the tests, these can be managed via JSON config file.
 
-| Name          | Default                      | Function |
-| ----          | -------                      | -------- |
-| TEST\_PATTERN | `**/*_test.py`          | Pattern to find tests. `**` for any recursive directory, `*` as normal wildcard |
+Place a copy of trafficlight-sample.json in instance/trafficlight.json [not in source control] to configure the application.
 
-Set these options via environment variables by prefixing with `TRAFFICLIGHT_`, eg: `TRAFFICLIGHT_TEST_PATTERN=only_one_test.py`.
+Rather than starting a synapse each time, and to reduce moving parts in some situations, we can override the use of complement to create homeservers and instead use static servers.
+
+These are best configured as referenced in the trafficlight-sample.json file.
 
 ## Releasing
 

--- a/trafficlight-sample.json
+++ b/trafficlight-sample.json
@@ -1,0 +1,31 @@
+{
+  "TEST_PATTERN": "/**/*_test.py",
+  "UPLOAD_FOLDER": "/tmp",
+  "SERVER_OVERRIDES": {
+      "SynapseStable":
+         [{
+            "server_name": "hs1",
+            "cs_api": "http://localhost/"
+         }],
+      "SynapseDevelop":
+         [{
+            "server_name": "hs1",
+            "cs_api": "http://localhost/"
+         }],
+      "Dendrite": 
+         [{
+            "server_name": "hs1",
+            "cs_api": "http://localhost/"
+         }],
+      "TwoSynapseFederation":
+
+         [{
+            "server_name": "hs1",
+            "cs_api": "http://localhost/"
+         }, 
+         {  
+            "server_name": "hs2",
+            "cs_api": "http://localhost"
+         }]
+  }
+}

--- a/trafficlight/__init__.py
+++ b/trafficlight/__init__.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import json
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
@@ -46,22 +47,26 @@ def format_delaytime(value: datetime) -> str:
 
 def create_app(test_config: Optional[Dict[str, Any]] = None) -> Quart:
     app = Quart(__name__, instance_relative_config=True)
+
     # Defaults here:
     app.config.update(
         {
             "TEST_PATTERN": "/**/*_test.py",
             "UPLOAD_FOLDER": "/tmp/",
+            "SERVER_OVERRIDES": {},
         }
     )
 
-    # Allows override via env var: TRAFFICLIGHT_<key>;
-    app.config.from_prefixed_env(prefix="TRAFFICLIGHT")
+    # Load configuration from JSON file
+    app.config.from_file("trafficlight.json", json.load)
 
     # TODO: ensure uploads folder is available
     # can i create README.md in there with a comment, for instance...
 
     # ensure the instance folder exists
-    print(f"{app.config}")
+    print(f"Test Pattern: {app.config.get('TEST_PATTERN')}")
+    print(f"Upload Folder: {app.config.get('UPLOAD_FOLDER')}")
+    print(f"Overrides: {app.config.get('SERVER_OVERRIDES')}")
 
     loaded_tests = load_tests(
         app.config.get("TEST_PATTERN"),

--- a/trafficlight/tests/__init__.py
+++ b/trafficlight/tests/__init__.py
@@ -68,7 +68,6 @@ def load_tests_from_module(module_name: str) -> List[Test]:
     tests: List[Test] = []
     for name in dir(module):
         obj = getattr(module, name)
-        logger.info(obj)
         if isinstance(obj, type) and issubclass(obj, Test) and not obj == Test:
             logger.info(f"Found Test {obj}")
             test = obj()


### PR DESCRIPTION
Basically, json is easier to configure things like homeserver overrides compared to envvars.