### PR TITLE
Permit static server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/instance/
 /venv
 /build
 /.idea

--- a/trafficlight/__init__.py
+++ b/trafficlight/__init__.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Optional
 from quart import Quart
 
 import trafficlight
+from trafficlight.homerunner import HomerunnerClient
 from trafficlight.http.adapter import (
     adapter_shutdown,
     loop_check_for_new_tests,
@@ -53,6 +54,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Quart:
         {
             "TEST_PATTERN": "/**/*_test.py",
             "UPLOAD_FOLDER": "/tmp/",
+            "HOMERUNNER_URL": "http://localhost:4090",
             "SERVER_OVERRIDES": {},
         }
     )
@@ -86,6 +88,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None) -> Quart:
     app.register_blueprint(status.bp)
     app.register_blueprint(root.bp)
 
+    app.config["homerunner"] = HomerunnerClient(app.config["HOMERUNNER_URL"], app.config["SERVER_OVERRIDES"])
     app.jinja_env.filters["delaytime"] = format_delaytime
 
     @app.before_serving

--- a/trafficlight/__init__.py
+++ b/trafficlight/__init__.py
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 import json
+import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 

--- a/trafficlight/http/adapter.py
+++ b/trafficlight/http/adapter.py
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
 # TODO: change this, but we need to provide versioning for clients :|
 bp = Blueprint("client", __name__, url_prefix="/client")
 
-homerunner = HomerunnerClient("http://localhost:54321")
 
 
 async def check_for_new_tests() -> None:
@@ -59,6 +58,7 @@ async def check_for_new_tests() -> None:
             if adapters_required is not None:
                 logger.info("Starting test %s", test_case)
 
+                homerunner = current_app.config["homerunner"]
                 async def run() -> None:
                     await test_case.run(adapters_required, homerunner)
 

--- a/trafficlight/internals/client.py
+++ b/trafficlight/internals/client.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from typing import Any, Dict, Optional, Union
+import time
 
 from trafficlight.homerunner import HomeServer
 
@@ -120,7 +121,7 @@ class MatrixClient(Client):
     def __init__(self, name: str, test_case: Any, registration: Dict[str, Any]):
         super().__init__(name, test_case, registration)
         # Client login details
-        self.localpart = "user_" + name
+        self.localpart = "user_" + name + "_" + str(round(time.time()))
         self.password = "pass_bibble_bobble_" + name
 
     # exposed to the test to act

--- a/trafficlight/internals/testcase.py
+++ b/trafficlight/internals/testcase.py
@@ -79,7 +79,7 @@ class TestCase:
             adapter.set_client(client)
             kwargs[client_var_name] = client
 
-        homeservers = await self.server_type.create(self.guid, homerunner)
+        homeservers = await homerunner.create(self.guid, self.server_type)
         for i in range(0, len(self.server_names)):
             kwargs[self.server_names[i]] = homeservers[i]
 

--- a/trafficlight/server_types.py
+++ b/trafficlight/server_types.py
@@ -1,54 +1,35 @@
 from typing import List
 
-from trafficlight.homerunner import HomerunnerClient, HomeServer
-
 
 class ServerType(object):
     def name(self) -> str:
         return type(self).__name__
 
+    def complement_types(self) -> List[str]:
+        pass
+
     def __repr__(self) -> str:
         return self.name()
 
-    async def create(
-        self, test_case_id: str, homerunner: HomerunnerClient
-    ) -> List[HomeServer]:
-        pass
-
 
 class SynapseStable(ServerType):
-    async def create(
-        self, test_case_id: str, homerunner: HomerunnerClient
-    ) -> List[HomeServer]:
-        return await homerunner.create(
-            test_case_id, ["ghcr.io/matrix-org/synapse/complement-synapse:master"]
-        )
+    def complement_types(self) -> List[str]:
+        return ["ghcr.io/matrix-org/synapse/complement-synapse:master"]
 
 
 class SynapseDevelop(ServerType):
-    async def create(
-        self, test_case_id: str, homerunner: HomerunnerClient
-    ) -> List[HomeServer]:
-        return await homerunner.create(
-            test_case_id, ["ghcr.io/matrix-org/synapse/complement-synapse:develop"]
-        )
+    def complement_types(self) -> List[str]:
+        return ["ghcr.io/matrix-org/synapse/complement-synapse:develop"]
 
 
 class Dendrite(ServerType):
-    async def create(
-        self, test_case_id: str, homerunner: HomerunnerClient
-    ) -> List[HomeServer]:
-        return await homerunner.create(test_case_id, ["complement-dendrite"])
+    def complement_types(self) -> List[str]:
+        return ["complement-dendrite"]
 
 
 class TwoSynapseFederation(ServerType):
-    async def create(
-        self, test_case_id: str, homerunner: HomerunnerClient
-    ) -> List[HomeServer]:
-        return await homerunner.create(
-            test_case_id,
-            [
-                "ghcr.io/matrix-org/synapse/complement-synapse:develop",
-                "ghcr.io/matrix-org/synapse/complement-synapse:develop",
-            ],
-        )
+    def complement_types(self) -> List[str]:
+        return [
+            "ghcr.io/matrix-org/synapse/complement-synapse:develop",
+            "ghcr.io/matrix-org/synapse/complement-synapse:develop",
+        ]


### PR DESCRIPTION
Rather than use complement to setup servers each time; allow a static config file to map server types to hosts.

This permits easier deployment in situations where server isolation is not key; but it's hard to get complement and the dockerd it requires running.